### PR TITLE
Use swmr in Subclassed xspress3 Handlers

### DIFF
--- a/startup/02-tiled-writer.py
+++ b/startup/02-tiled-writer.py
@@ -1,4 +1,5 @@
 import math
+import copy
 import numpy
 import os
 import warnings
@@ -178,6 +179,8 @@ LENGTH = 100_000
 
 
 def patch_descriptor(doc):
+    doc = copy.deepcopy(doc)
+
     if "pb1_enc1" in doc["data_keys"]:
         data_key = doc["data_keys"]["pb1_enc1"]
         data_key["dtype_str"] = pb1_dtype.str
@@ -228,6 +231,7 @@ def patch_descriptor(doc):
     return doc
 
 def patch_datum(doc):
+    doc = copy.deepcopy(doc)
     kwargs = doc.get("datum_kwargs", {})
 
     # Override indices with the point_number if present:
@@ -239,7 +243,7 @@ def patch_datum(doc):
     return doc
 
 def patch_resource(doc):
-
+    doc = copy.deepcopy(doc)
     kwargs = doc.get("resource_kwargs", {})
 
     # Fix the resource path
@@ -476,5 +480,5 @@ tw = BufferingWrapper(tw)
 RE.md["tiled_access_tags"] = ("qas_beamline",)   # This is general QAS access tag
 
 # Subscribe the TiledWriter
-# RE.subscribe(tw)
+RE.subscribe(tw)
 

--- a/startup/11-handlers.py
+++ b/startup/11-handlers.py
@@ -4,6 +4,7 @@ from itertools import product
 
 import pandas as pd
 from databroker.assets.handlers import HandlerBase, Xspress3HDF5Handler, XS3_XRF_DATA_KEY
+import h5py
 
 
 fc = 7.62939453125e-05
@@ -155,6 +156,12 @@ class QASXspress3HDF5Handler(Xspress3HDF5Handler):
                           columns=[f'ch_{n+1}' for n in range(num_channels)])
         #return pd.concat([df]+[attrsdf])
         return df
+
+    def open(self):
+        if self._file:
+            return
+
+        self._file = h5py.File(self._filename, "r", swmr=True)
 
 db.reg.register_handler('PIZZABOX_AN_FILE_TXT',
                         PizzaBoxAnHandlerTxt, overwrite=True)

--- a/startup/40-xspress3.py
+++ b/startup/40-xspress3.py
@@ -31,6 +31,7 @@ import itertools
 import time as ttime
 from collections import deque, OrderedDict
 import warnings
+import h5py
 
 
 class Xspress3FileStoreFlyable(Xspress3FileStore):
@@ -428,6 +429,12 @@ class QASXspress3HDF5Handler(Xspress3HDF5Handler):
         return_dict_rois = {chanroi: self._roi_data[chanroi][frame] for chanroi in self.chanrois}
         return {**return_dict, **return_dict_rois}
 
+    def open(self):
+        if self._file:
+            return
+
+        self._file = h5py.File(self._filename, "r", swmr=True)
+
 
 # heavy-weight file handler
 db.reg.register_handler(QASXspress3HDF5Handler.HANDLER_NAME,
@@ -470,6 +477,12 @@ class QASXspress3HDF5Handler_light(Xspress3HDF5Handler):
         return_dict_rois = {chanroi: self._roi_data[chanroi][frame] for chanroi in self.chanrois}
         # return {**return_dict, **return_dict_rois}
         return return_dict_rois
+
+    def open(self):
+        if self._file:
+            return
+
+        self._file = h5py.File(self._filename, "r", swmr=True)
 
     # db.reg.register_handler(QASXspress3HDF5Handler_light.HANDLER_NAME,
     #                         QASXspress3HDF5Handler_light, overwrite=True)

--- a/startup/41-xspress3x.py
+++ b/startup/41-xspress3x.py
@@ -17,6 +17,7 @@ from ophyd.device import Staged
 from ophyd.sim import NullStatus
 from enum import Enum
 from collections import deque, OrderedDict
+import h5py
 
 from ophyd.areadetector import Xspress3Detector
 from nslsii.areadetector.xspress3 import (
@@ -247,6 +248,12 @@ class QASXspress3XHDF5Handler(Xspress3HDF5Handler):
         # arr_data = np.asarray(self._file[self.XRF_DATA_KEY])
         # print(arr_data.shape)
         return self._array_data[frame_number, :, :]
+
+    def open(self):
+        if self._file:
+            return
+
+        self._file = h5py.File(self._filename, "r", swmr=True)
 
 
 # heavy-weight file handler


### PR DESCRIPTION
Sets `swmr = True` in handlers that open hdf5 files to enable simultaneous access from DataBroker and Tiled.