### PR TITLE
🐆 Implement tiled quality-of-service for priority requests

### DIFF
--- a/startup/02-tiled-writer.py
+++ b/startup/02-tiled-writer.py
@@ -293,6 +293,7 @@ CONSOLIDATOR_REGISTRY.update({'application/x-pizzabox-binary': PizzaBoxConsolida
 # Initialize the Tiled client and the TiledWriter
 api_key = os.environ.get("TILED_BLUESKY_WRITING_API_KEY_QAS")
 tiled_writing_client_sql = from_uri("https://tiled.nsls2.bnl.gov", api_key=api_key)['qas']['migration']
+tiled_writing_client_sql.context.http_client.headers['tiled-qos'] = 'acquisition'
 tw = TiledWriter(client = tiled_writing_client_sql,
                  backup_directory="/tmp/tiled_backup",
                  patches = {"descriptor": patch_descriptor,


### PR DESCRIPTION
Tiled recently added a mechanism to ensure that critical path writing requests made during data acquisition go through, while other Prefect workflows that are not as tightly coupled to operations are put on a scheduled queue such that the Tiled servers will be less likely to become saturated / go down / become unavailable e.g.